### PR TITLE
feat: add participant anniversary plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "ngs-harco/participant-anniversary",
+  "description": "Participant anniversary plugin",
+  "type": "shopware-platform-plugin",
+  "license": "MIT",
+  "require": {
+    "shopware/core": "^6.5",
+    "endroid/qr-code": "^4.8"
+  },
+  "autoload": {
+    "psr-4": {
+      "NgsHarco\\ParticipantAnniversary\\": "src/"
+    }
+  }
+}

--- a/src/Command/CheckAnniversariesCommand.php
+++ b/src/Command/CheckAnniversariesCommand.php
@@ -1,0 +1,25 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Command;
+
+use NgsHarco\ParticipantAnniversary\Service\AnniversaryService;
+use Shopware\Core\Framework\Context;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'ngs-harco:participants:check-anniversaries')]
+class CheckAnniversariesCommand extends Command
+{
+    public function __construct(private readonly AnniversaryService $service)
+    {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $count = $this->service->processToday(Context::createDefaultContext());
+        $output->writeln(sprintf('Processed %d anniversaries', $count));
+        return self::SUCCESS;
+    }
+}

--- a/src/Controller/Admin/ParticipantImportController.php
+++ b/src/Controller/Admin/ParticipantImportController.php
@@ -1,0 +1,69 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Controller\Admin;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class ParticipantImportController
+{
+    public function __construct(private readonly EntityRepository $participantRepository)
+    {
+    }
+
+    #[Route(path: '/_action/ngs-harco/participants/import', name: 'ngs-harco.participants.import', methods: ['POST'])]
+    public function import(Request $request): JsonResponse
+    {
+        $file = $request->files->get('file');
+        if (!$file) {
+            return new JsonResponse(['error' => 'No file uploaded'], 400);
+        }
+        $handle = fopen($file->getPathname(), 'r');
+        $headers = fgetcsv($handle);
+        $required = ['first_name','last_name','email','work_start_date'];
+        if (array_diff($required, $headers)) {
+            return new JsonResponse(['error' => 'Missing headers'], 400);
+        }
+        $created = $updated = 0; $failed = [];
+        $line = 1;
+        while (($row = fgetcsv($handle)) !== false) {
+            $line++;
+            $data = array_combine($headers, $row);
+            if (!filter_var($data['email'], FILTER_VALIDATE_EMAIL)) {
+                $failed[] = ['line' => $line, 'reason' => 'Invalid email'];
+                continue;
+            }
+            $start = \DateTime::createFromFormat('Y-m-d', $data['work_start_date']);
+            if (!$start) {
+                $failed[] = ['line' => $line, 'reason' => 'Invalid start date'];
+                continue;
+            }
+            $context = Context::createDefaultContext();
+            $existing = $this->participantRepository->search((new Criteria())
+                ->addFilter(new EqualsFilter('email', $data['email'])), $context);
+            $payload = [
+                'firstName' => $data['first_name'],
+                'lastName' => $data['last_name'],
+                'email' => $data['email'],
+                'workStartDate' => $data['work_start_date'],
+                'workEndDate' => $data['work_end_date'] ?: null,
+            ];
+            if ($existing->first()) {
+                $payload['id'] = $existing->first()->getId();
+                $this->participantRepository->update([$payload], $context);
+                $updated++;
+            } else {
+                $payload['id'] = Uuid::randomHex();
+                $this->participantRepository->create([$payload], $context);
+                $created++;
+            }
+        }
+        fclose($handle);
+        return new JsonResponse(['created' => $created, 'updated' => $updated, 'failed' => $failed]);
+    }
+}

--- a/src/Controller/Storefront/AccessController.php
+++ b/src/Controller/Storefront/AccessController.php
@@ -1,0 +1,53 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Controller\Storefront;
+
+use NgsHarco\ParticipantAnniversary\Service\ConfigService;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Storefront\Controller\StorefrontController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class AccessController extends StorefrontController
+{
+    public function __construct(
+        private readonly EntityRepository $anniversaryLogRepository,
+        private readonly ConfigService $config,
+    ) {
+    }
+
+    #[Route(path: '/ngs-harco/access/{token}', name: 'frontend.ngs_harco.access', methods: ['GET'])]
+    public function access(string $token, Request $request, SalesChannelContext $salesChannelContext): Response
+    {
+        $criteria = (new Criteria())->addFilter(new EqualsFilter('token', $token));
+        $log = $this->anniversaryLogRepository->search($criteria, $salesChannelContext->getContext())->first();
+        if (!$log) {
+            return $this->createErrorResponse();
+        }
+        if ($log->getUsedAt() || $log->getTokenExpiresAt() < new \DateTimeImmutable()) {
+            return $this->createErrorResponse();
+        }
+
+        $this->anniversaryLogRepository->update([
+            ['id' => $log->getId(), 'usedAt' => new \DateTimeImmutable()],
+        ], $salesChannelContext->getContext());
+
+        $request->getSession()->set('ngsHarco.levelProductId', $log->getLevelProductId());
+
+        $level = $this->config->findLevelForYears($log->getAnniversaryYear());
+        $categoryId = $level['targetCategoryId'] ?? $this->config->fallbackCategoryId();
+        if ($categoryId) {
+            return $this->redirectToRoute('frontend.navigation.page', ['navigationId' => $categoryId]);
+        }
+
+        return $this->redirectToRoute('frontend.home.page');
+    }
+
+    private function createErrorResponse(): Response
+    {
+        return $this->renderStorefront('@Storefront/storefront/page/content/not-found.html.twig', []);
+    }
+}

--- a/src/Core/Content/Participant/ParticipantCollection.php
+++ b/src/Core/Content/Participant/ParticipantCollection.php
@@ -1,0 +1,21 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Core\Content\Participant;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @method void              add(ParticipantEntity $entity)
+ * @method void              set(string $key, ParticipantEntity $entity)
+ * @method ParticipantEntity[]    getIterator()
+ * @method ParticipantEntity[]    getElements()
+ * @method ParticipantEntity|null get(string $key)
+ * @method ParticipantEntity|null first()
+ * @method ParticipantEntity|null last()
+ */
+class ParticipantCollection extends EntityCollection
+{
+    protected function getExpectedClass(): string
+    {
+        return ParticipantEntity::class;
+    }
+}

--- a/src/Core/Content/Participant/ParticipantDefinition.php
+++ b/src/Core/Content/Participant/ParticipantDefinition.php
@@ -1,0 +1,47 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Core\Content\Participant;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedAtField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\EmailField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\UuidField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class ParticipantDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'ngs_harco_participant';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getEntityClass(): string
+    {
+        return ParticipantEntity::class;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return ParticipantCollection::class;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new UuidField('id', 'id'))->addFlags(new Required(), new PrimaryKey()),
+            (new StringField('first_name', 'firstName'))->addFlags(new Required()),
+            (new StringField('last_name', 'lastName'))->addFlags(new Required()),
+            (new EmailField('email', 'email'))->addFlags(new Required()),
+            (new DateField('work_start_date', 'workStartDate'))->addFlags(new Required()),
+            new DateField('work_end_date', 'workEndDate'),
+            new CreatedAtField(),
+            new UpdatedAtField(),
+        ]);
+    }
+}

--- a/src/Core/Content/Participant/ParticipantEntity.php
+++ b/src/Core/Content/Participant/ParticipantEntity.php
@@ -1,0 +1,66 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Core\Content\Participant;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+
+class ParticipantEntity extends Entity
+{
+    use EntityIdTrait;
+
+    protected string $firstName;
+    protected string $lastName;
+    protected string $email;
+    protected \DateTimeInterface $workStartDate;
+    protected ?\DateTimeInterface $workEndDate;
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(string $firstName): void
+    {
+        $this->firstName = $firstName;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(string $lastName): void
+    {
+        $this->lastName = $lastName;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): void
+    {
+        $this->email = $email;
+    }
+
+    public function getWorkStartDate(): \DateTimeInterface
+    {
+        return $this->workStartDate;
+    }
+
+    public function setWorkStartDate(\DateTimeInterface $date): void
+    {
+        $this->workStartDate = $date;
+    }
+
+    public function getWorkEndDate(): ?\DateTimeInterface
+    {
+        return $this->workEndDate;
+    }
+
+    public function setWorkEndDate(?\DateTimeInterface $date): void
+    {
+        $this->workEndDate = $date;
+    }
+}

--- a/src/Core/Content/ParticipantAnniversaryLog/AnniversaryLogCollection.php
+++ b/src/Core/Content/ParticipantAnniversaryLog/AnniversaryLogCollection.php
@@ -1,0 +1,21 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Core\Content\ParticipantAnniversaryLog;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @method void                add(AnniversaryLogEntity $entity)
+ * @method void                set(string $key, AnniversaryLogEntity $entity)
+ * @method AnniversaryLogEntity[]    getIterator()
+ * @method AnniversaryLogEntity[]    getElements()
+ * @method AnniversaryLogEntity|null get(string $key)
+ * @method AnniversaryLogEntity|null first()
+ * @method AnniversaryLogEntity|null last()
+ */
+class AnniversaryLogCollection extends EntityCollection
+{
+    protected function getExpectedClass(): string
+    {
+        return AnniversaryLogEntity::class;
+    }
+}

--- a/src/Core/Content/ParticipantAnniversaryLog/AnniversaryLogDefinition.php
+++ b/src/Core/Content/ParticipantAnniversaryLog/AnniversaryLogDefinition.php
@@ -1,0 +1,47 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Core\Content\ParticipantAnniversaryLog;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedAtField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\UuidField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class AnniversaryLogDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'ngs_harco_participant_anniversary_log';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getEntityClass(): string
+    {
+        return AnniversaryLogEntity::class;
+    }
+
+    public function getCollectionClass(): string
+    {
+        return AnniversaryLogCollection::class;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new UuidField('id', 'id'))->addFlags(new Required(), new PrimaryKey()),
+            (new UuidField('participant_id', 'participantId'))->addFlags(new Required()),
+            (new IntField('anniversary_year', 'anniversaryYear'))->addFlags(new Required()),
+            new UuidField('level_product_id', 'levelProductId'),
+            (new StringField('token', 'token'))->addFlags(new Required()),
+            (new DateTimeField('token_expires_at', 'tokenExpiresAt'))->addFlags(new Required()),
+            new DateTimeField('used_at', 'usedAt'),
+            (new DateTimeField('sent_at', 'sentAt'))->addFlags(new Required()),
+            new CreatedAtField(),
+        ]);
+    }
+}

--- a/src/Core/Content/ParticipantAnniversaryLog/AnniversaryLogEntity.php
+++ b/src/Core/Content/ParticipantAnniversaryLog/AnniversaryLogEntity.php
@@ -1,0 +1,88 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Core\Content\ParticipantAnniversaryLog;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+
+class AnniversaryLogEntity extends Entity
+{
+    use EntityIdTrait;
+
+    protected string $participantId;
+    protected int $anniversaryYear;
+    protected ?string $levelProductId;
+    protected string $token;
+    protected \DateTimeInterface $tokenExpiresAt;
+    protected ?\DateTimeInterface $usedAt;
+    protected \DateTimeInterface $sentAt;
+
+    public function getParticipantId(): string
+    {
+        return $this->participantId;
+    }
+
+    public function setParticipantId(string $participantId): void
+    {
+        $this->participantId = $participantId;
+    }
+
+    public function getAnniversaryYear(): int
+    {
+        return $this->anniversaryYear;
+    }
+
+    public function setAnniversaryYear(int $year): void
+    {
+        $this->anniversaryYear = $year;
+    }
+
+    public function getLevelProductId(): ?string
+    {
+        return $this->levelProductId;
+    }
+
+    public function setLevelProductId(?string $id): void
+    {
+        $this->levelProductId = $id;
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    public function setToken(string $token): void
+    {
+        $this->token = $token;
+    }
+
+    public function getTokenExpiresAt(): \DateTimeInterface
+    {
+        return $this->tokenExpiresAt;
+    }
+
+    public function setTokenExpiresAt(\DateTimeInterface $expires): void
+    {
+        $this->tokenExpiresAt = $expires;
+    }
+
+    public function getUsedAt(): ?\DateTimeInterface
+    {
+        return $this->usedAt;
+    }
+
+    public function setUsedAt(?\DateTimeInterface $usedAt): void
+    {
+        $this->usedAt = $usedAt;
+    }
+
+    public function getSentAt(): \DateTimeInterface
+    {
+        return $this->sentAt;
+    }
+
+    public function setSentAt(\DateTimeInterface $sentAt): void
+    {
+        $this->sentAt = $sentAt;
+    }
+}

--- a/src/Event/ParticipantWorkAnniversaryEvent.php
+++ b/src/Event/ParticipantWorkAnniversaryEvent.php
@@ -1,0 +1,70 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\FlowEventAware;
+use Shopware\Core\Framework\Event\StorableFlowEvent;
+
+class ParticipantWorkAnniversaryEvent extends StorableFlowEvent implements FlowEventAware
+{
+    public const NAME = 'ngs_harco.participant.work_anniversary';
+
+    public function __construct(
+        private readonly string $participantId,
+        private readonly string $email,
+        private readonly string $firstName,
+        private readonly string $lastName,
+        private readonly int $anniversaryYear,
+        private readonly ?string $levelProductId,
+        private readonly string $loginLink,
+        private readonly ?string $qrCodeDataUri,
+        Context $context
+    ) {
+        parent::__construct($context);
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+
+    public function getParticipantId(): string
+    {
+        return $this->participantId;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function getAnniversaryYear(): int
+    {
+        return $this->anniversaryYear;
+    }
+
+    public function getLevelProductId(): ?string
+    {
+        return $this->levelProductId;
+    }
+
+    public function getLoginLink(): string
+    {
+        return $this->loginLink;
+    }
+
+    public function getQrCodeDataUri(): ?string
+    {
+        return $this->qrCodeDataUri;
+    }
+}

--- a/src/Event/Storer/ParticipantWorkAnniversaryStorer.php
+++ b/src/Event/Storer/ParticipantWorkAnniversaryStorer.php
@@ -1,0 +1,47 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Event\Storer;
+
+use NgsHarco\ParticipantAnniversary\Event\ParticipantWorkAnniversaryEvent;
+use Shopware\Core\Framework\Event\FlowEventAware;
+use Shopware\Core\Framework\Event\Storer\FlowStorer;
+use Shopware\Core\Framework\Event\Storer\FlowStorerPriority;
+
+class ParticipantWorkAnniversaryStorer extends FlowStorer
+{
+    public function getPriority(): int
+    {
+        return FlowStorerPriority::DEFAULT;
+    }
+
+    public function store(FlowEventAware $event, array $stored): array
+    {
+        if (!$event instanceof ParticipantWorkAnniversaryEvent) {
+            return $stored;
+        }
+
+        $stored[ParticipantWorkAnniversaryEvent::NAME] = [
+            'participantId' => $event->getParticipantId(),
+            'email' => $event->getEmail(),
+            'firstName' => $event->getFirstName(),
+            'lastName' => $event->getLastName(),
+            'anniversaryYear' => $event->getAnniversaryYear(),
+            'levelProductId' => $event->getLevelProductId(),
+            'loginLink' => $event->getLoginLink(),
+            'qrCodeDataUri' => $event->getQrCodeDataUri(),
+        ];
+
+        return $stored;
+    }
+
+    public function restore(FlowEventAware $event, array $stored): void
+    {
+        if (!$event instanceof ParticipantWorkAnniversaryEvent) {
+            return;
+        }
+
+        $data = $stored[ParticipantWorkAnniversaryEvent::NAME] ?? [];
+        if ($data) {
+            $event->setData($data);
+        }
+    }
+}

--- a/src/Migration/Migration202404030000AddParticipant.php
+++ b/src/Migration/Migration202404030000AddParticipant.php
@@ -1,0 +1,34 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration202404030000AddParticipant extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 202404030000;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement(
+            'CREATE TABLE IF NOT EXISTS `ngs_harco_participant` (
+                `id` BINARY(16) NOT NULL,
+                `first_name` VARCHAR(255) NOT NULL,
+                `last_name` VARCHAR(255) NOT NULL,
+                `email` VARCHAR(255) NOT NULL UNIQUE,
+                `work_start_date` DATE NOT NULL,
+                `work_end_date` DATE NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+        );
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Migration/Migration202404030001AddAnniversaryLog.php
+++ b/src/Migration/Migration202404030001AddAnniversaryLog.php
@@ -1,0 +1,38 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration202404030001AddAnniversaryLog extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 202404030001;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement(
+            'CREATE TABLE IF NOT EXISTS `ngs_harco_participant_anniversary_log` (
+                `id` BINARY(16) NOT NULL,
+                `participant_id` BINARY(16) NOT NULL,
+                `anniversary_year` INT NOT NULL,
+                `level_product_id` BINARY(16) NULL,
+                `token` VARCHAR(128) NOT NULL UNIQUE,
+                `token_expires_at` DATETIME(3) NOT NULL,
+                `used_at` DATETIME(3) NULL,
+                `sent_at` DATETIME(3) NOT NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                PRIMARY KEY (`id`),
+                CONSTRAINT `fk.ngs_harco_participant_anniversary_log.participant_id`
+                    FOREIGN KEY (`participant_id`) REFERENCES `ngs_harco_participant` (`id`) ON DELETE CASCADE,
+                INDEX `idx.participant_year` (`participant_id`,`anniversary_year`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci'
+        );
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/NgsHarcoParticipantAnniversary.php
+++ b/src/NgsHarcoParticipantAnniversary.php
@@ -1,0 +1,19 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary;
+
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Context\InstallContext;
+use Shopware\Core\Framework\Plugin\Context\UninstallContext;
+
+class NgsHarcoParticipantAnniversary extends Plugin
+{
+    public function install(InstallContext $installContext): void
+    {
+        parent::install($installContext);
+    }
+
+    public function uninstall(UninstallContext $uninstallContext): void
+    {
+        parent::uninstall($uninstallContext);
+    }
+}

--- a/src/Resources/app/administration/src/module/participants/index.js
+++ b/src/Resources/app/administration/src/module/participants/index.js
@@ -1,0 +1,26 @@
+import './page/participants-import';
+
+Shopware.Module.register('ngs-harco-participants', {
+    type: 'plugin',
+    name: 'Participants',
+    title: 'Participants',
+    description: 'Import participants',
+    color: '#ff3d58',
+    icon: 'default-communication-mail',
+    routes: {
+        index: {
+            component: 'ngs-harco-participants-import',
+            path: 'index'
+        }
+    },
+    navigation: [
+        {
+            label: 'Participants',
+            color: '#ff3d58',
+            path: 'ngs.harcoparticipants.index',
+            icon: 'default-communication-mail',
+            parent: 'sw-marketing',
+            position: 100
+        }
+    ]
+});

--- a/src/Resources/app/administration/src/module/participants/page/participants-import/index.html.twig
+++ b/src/Resources/app/administration/src/module/participants/page/participants-import/index.html.twig
@@ -1,0 +1,9 @@
+{% block ngs_harco_participants_import %}
+<div>
+    <input type="file" @change="onChangeFile" />
+    <sw-button @click="onUpload">Upload</sw-button>
+    <div v-if="result">
+        <pre>{{ result }}</pre>
+    </div>
+</div>
+{% endblock %}

--- a/src/Resources/app/administration/src/module/participants/page/participants-import/index.js
+++ b/src/Resources/app/administration/src/module/participants/page/participants-import/index.js
@@ -1,0 +1,28 @@
+import template from './index.html.twig';
+
+const { Component } = Shopware;
+
+Component.register('ngs-harco-participants-import', {
+    template,
+    data() {
+        return {
+            file: null,
+            result: null
+        };
+    },
+    methods: {
+        onChangeFile(event) {
+            this.file = event.target.files[0];
+        },
+        onUpload() {
+            if (!this.file) {
+                return;
+            }
+            const formData = new FormData();
+            formData.append('file', this.file);
+            this.$http.post('/_action/ngs-harco/participants/import', formData).then(response => {
+                this.result = response.data;
+            });
+        }
+    }
+});

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="NgsHarco\ParticipantAnniversary\Service\ConfigService">
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+        </service>
+
+        <service id="NgsHarco\ParticipantAnniversary\Service\LoginLinkService" />
+        <service id="NgsHarco\ParticipantAnniversary\Service\QrCodeService" />
+
+        <service id="NgsHarco\ParticipantAnniversary\Service\AnniversaryService">
+            <argument type="service" id="NgsHarco\ParticipantAnniversary\Core\Content\Participant\ParticipantDefinition.repository" />
+            <argument type="service" id="NgsHarco\ParticipantAnniversary\Core\Content\ParticipantAnniversaryLog\AnniversaryLogDefinition.repository" />
+            <argument type="service" id="NgsHarco\ParticipantAnniversary\Service\ConfigService" />
+            <argument type="service" id="NgsHarco\ParticipantAnniversary\Service\LoginLinkService" />
+            <argument type="service" id="NgsHarco\ParticipantAnniversary\Service\QrCodeService" />
+            <argument type="service" id="event_dispatcher" />
+        </service>
+
+        <service id="NgsHarco\ParticipantAnniversary\Command\CheckAnniversariesCommand">
+            <argument type="service" id="NgsHarco\ParticipantAnniversary\Service\AnniversaryService" />
+            <tag name="console.command" />
+        </service>
+
+        <service id="NgsHarco\ParticipantAnniversary\Event\Storer\ParticipantWorkAnniversaryStorer">
+            <tag name="shopware.flow.event_storer" />
+        </service>
+
+        <service id="NgsHarco\ParticipantAnniversary\Controller\Storefront\AccessController" public="true">
+            <argument type="service" id="NgsHarco\ParticipantAnniversary\Core\Content\ParticipantAnniversaryLog\AnniversaryLogDefinition.repository" />
+            <argument type="service" id="NgsHarco\ParticipantAnniversary\Service\ConfigService" />
+            <tag name="controller.service_arguments" />
+            <tag name="shopware.storefront.controller" />
+        </service>
+        <service id="NgsHarco\ParticipantAnniversary\Controller\Admin\ParticipantImportController" public="true">
+            <argument type="service" id="NgsHarco\ParticipantAnniversary\Core\Content\Participant\ParticipantDefinition.repository" />
+            <tag name="controller.service_arguments" />
+            <tag name="shopware.controller" />
+        </service>
+    </services>
+</container>

--- a/src/Resources/config/system.xml
+++ b/src/Resources/config/system.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" ?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://shopware.github.io/schemas/system-config/1.0/system-config.xsd">
+    <card>
+        <title>Levels</title>
+        <label>Level mapping</label>
+        <input-field>
+            <name>levelMappings</name>
+            <label>Level mappings (JSON)</label>
+            <type>text</type>
+            <component>sw-textarea-field</component>
+        </input-field>
+    </card>
+    <card>
+        <title>Settings</title>
+        <input-field>
+            <name>tokenTtlDays</name>
+            <label>Token TTL (days)</label>
+            <type>int</type>
+            <defaultValue>7</defaultValue>
+        </input-field>
+        <input-field>
+            <name>fallbackCategoryId</name>
+            <label>Fallback category</label>
+            <type>text</type>
+            <component>sw-entity-single-select</component>
+            <config>
+                <entity>category</entity>
+            </config>
+        </input-field>
+        <input-field>
+            <name>generateQrCode</name>
+            <label>Generate QR Code</label>
+            <type>bool</type>
+        </input-field>
+        <input-field>
+            <name>qrSize</name>
+            <label>QR Code size</label>
+            <type>int</type>
+            <defaultValue>256</defaultValue>
+        </input-field>
+    </card>
+</config>

--- a/src/Service/AnniversaryService.php
+++ b/src/Service/AnniversaryService.php
@@ -1,0 +1,99 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Service;
+
+use NgsHarco\ParticipantAnniversary\Event\ParticipantWorkAnniversaryEvent;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class AnniversaryService
+{
+    public function __construct(
+        private readonly EntityRepository $participantRepository,
+        private readonly EntityRepository $anniversaryLogRepository,
+        private readonly ConfigService $config,
+        private readonly LoginLinkService $loginLinkService,
+        private readonly QrCodeService $qrCodeService,
+        private readonly EventDispatcherInterface $dispatcher
+    ) {
+    }
+
+    public function processToday(Context $context): int
+    {
+        $today = new \DateTimeImmutable('today');
+        $participants = $this->participantRepository->search(new Criteria(), $context);
+        $count = 0;
+
+        foreach ($participants as $participant) {
+            $start = $participant->getWorkStartDate();
+            if ($start->format('m-d') !== $today->format('m-d')) {
+                continue;
+            }
+            if ($start > $today) {
+                continue;
+            }
+            $end = $participant->getWorkEndDate();
+            if ($end && $end < $today) {
+                continue;
+            }
+            $years = $start->diff($today)->y;
+            $level = $this->config->findLevelForYears($years);
+            if (!$level) {
+                continue;
+            }
+
+            $criteria = (new Criteria())
+                ->addFilter(new EqualsFilter('participantId', $participant->getId()))
+                ->addFilter(new EqualsFilter('anniversaryYear', $years));
+            $existing = $this->anniversaryLogRepository->search($criteria, $context);
+            $alreadySent = false;
+            foreach ($existing as $log) {
+                if ($log->getSentAt()->format('Y') === $today->format('Y')) {
+                    $alreadySent = true;
+                    break;
+                }
+            }
+            if ($alreadySent) {
+                continue;
+            }
+
+            $token = bin2hex(random_bytes(32));
+            $expires = $today->modify('+' . $this->config->tokenTtlDays() . ' days');
+
+            $this->anniversaryLogRepository->create([
+                [
+                    'participantId' => $participant->getId(),
+                    'anniversaryYear' => $years,
+                    'levelProductId' => $level['productId'] ?? null,
+                    'token' => $token,
+                    'tokenExpiresAt' => $expires,
+                    'sentAt' => new \DateTimeImmutable(),
+                ]
+            ], $context);
+
+            $link = $this->loginLinkService->build($token);
+            $qr = null;
+            if ($this->config->generateQrCode()) {
+                $qr = $this->qrCodeService->generateDataUri($link, $this->config->qrSize());
+            }
+
+            $event = new ParticipantWorkAnniversaryEvent(
+                $participant->getId(),
+                $participant->getEmail(),
+                $participant->getFirstName(),
+                $participant->getLastName(),
+                $years,
+                $level['productId'] ?? null,
+                $link,
+                $qr,
+                $context
+            );
+            $this->dispatcher->dispatch($event);
+            ++$count;
+        }
+
+        return $count;
+    }
+}

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -1,0 +1,49 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Service;
+
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+
+class ConfigService
+{
+    private const CONFIG_DOMAIN = 'NgsHarcoParticipantAnniversary.config.';
+
+    public function __construct(private readonly SystemConfigService $configService)
+    {
+    }
+
+    public function getLevelMappings(): array
+    {
+        return $this->configService->get(self::CONFIG_DOMAIN . 'levelMappings') ?? [];
+    }
+
+    public function findLevelForYears(int $years): ?array
+    {
+        foreach ($this->getLevelMappings() as $mapping) {
+            if ((int) ($mapping['years'] ?? 0) === $years) {
+                return $mapping;
+            }
+        }
+
+        return null;
+    }
+
+    public function tokenTtlDays(): int
+    {
+        return (int) ($this->configService->get(self::CONFIG_DOMAIN . 'tokenTtlDays') ?? 7);
+    }
+
+    public function generateQrCode(): bool
+    {
+        return (bool) ($this->configService->get(self::CONFIG_DOMAIN . 'generateQrCode') ?? false);
+    }
+
+    public function qrSize(): int
+    {
+        return (int) ($this->configService->get(self::CONFIG_DOMAIN . 'qrSize') ?? 256);
+    }
+
+    public function fallbackCategoryId(): ?string
+    {
+        return $this->configService->get(self::CONFIG_DOMAIN . 'fallbackCategoryId');
+    }
+}

--- a/src/Service/LoginLinkService.php
+++ b/src/Service/LoginLinkService.php
@@ -1,0 +1,16 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Service;
+
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class LoginLinkService
+{
+    public function __construct(private readonly UrlGeneratorInterface $router)
+    {
+    }
+
+    public function build(string $token): string
+    {
+        return $this->router->generate('frontend.ngs_harco.access', ['token' => $token], UrlGeneratorInterface::ABSOLUTE_URL);
+    }
+}

--- a/src/Service/QrCodeService.php
+++ b/src/Service/QrCodeService.php
@@ -1,0 +1,23 @@
+<?php
+namespace NgsHarco\ParticipantAnniversary\Service;
+
+use Endroid\QrCode\Builder\Builder;
+use Endroid\QrCode\Encoding\Encoding;
+use Endroid\QrCode\ErrorCorrectionLevel\ErrorCorrectionLevelLow;
+use Endroid\QrCode\Writer\PngWriter;
+
+class QrCodeService
+{
+    public function generateDataUri(string $text, int $size): string
+    {
+        $result = Builder::create()
+            ->writer(new PngWriter())
+            ->data($text)
+            ->encoding(new Encoding('UTF-8'))
+            ->errorCorrectionLevel(new ErrorCorrectionLevelLow())
+            ->size($size)
+            ->build();
+
+        return 'data:image/png;base64,' . base64_encode($result->getString());
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold participant anniversary plugin with DAL entities, migrations and services
- add command to check anniversaries and emit flow event
- provide storefront magic-link access controller and admin CSV import

## Testing
- `composer validate --no-check-all --strict`
- `find src -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68c570a07d94832f9334e727eff7147a